### PR TITLE
Change API to provide a single modification point for scan result logic

### DIFF
--- a/lib/simulation/simulated_peripheral.dart
+++ b/lib/simulation/simulated_peripheral.dart
@@ -79,8 +79,12 @@ abstract class SimulatedPeripheral {
   Stream<ScanResult> onScan({bool allowDuplicates = true}) async* {
     do {
       await Future.delayed(advertisementInterval);
-      yield ScanResult(scanInfo, this);
+      yield scanResult();
     } while (allowDuplicates);
+  }
+
+  ScanResult scanResult() {
+    return ScanResult(scanInfo, this);
   }
 
   Future<bool> onConnectRequest() async {


### PR DESCRIPTION
It is impossible to properly override onScan if I'd like to change RSSI in every scan result. By extracting the logic behind, I can now create a peripheral with overrode scanResult and do
```dart
@override
ScanResult scanResult() {
  scanInfo.rssi = -Random.nextInt(50);
  return super.scanResult();
}
```