### PR TITLE
[iOS] Pass monitoring error as json string

### DIFF
--- a/ios/Classes/Error/BleError.h
+++ b/ios/Classes/Error/BleError.h
@@ -15,6 +15,8 @@
 
 - (instancetype)initWithErrorCode:(BleErrorCode)errorCode reason:(NSString *)reason;
 
+- (NSString *)jsonStringRepresentation;
+
 - (NSDictionary *)jsonObjectRepresentation;
 
 - (void)callReject:(Reject)reject;

--- a/ios/Classes/Error/BleError.m
+++ b/ios/Classes/Error/BleError.m
@@ -20,6 +20,10 @@
     return self;
 }
 
+- (NSString *)jsonStringRepresentation {
+    return [BlemulatorJSONStringifier jsonStringFromJSONObject:[self jsonObjectRepresentation]];
+}
+
 - (NSDictionary *)jsonObjectRepresentation {
     return [NSDictionary dictionaryWithObjectsAndKeys:
             [NSNumber numberWithInt:_errorCode], @"errorCode",

--- a/ios/Classes/SimulatedAdapter.m
+++ b/ios/Classes/SimulatedAdapter.m
@@ -65,7 +65,7 @@
 }
 
 - (void)dispatchDartValueHandlerReadError:(BleError *)bleError transactionId:(NSString *)transactionId {
-    [self.delegate dispatchEvent:BleEvent.readEvent value:[NSArray arrayWithObjects:[bleError jsonObjectRepresentation],
+    [self.delegate dispatchEvent:BleEvent.readEvent value:[NSArray arrayWithObjects:[bleError jsonStringRepresentation],
                                                            [NSNull null],
                                                            transactionId != nil ? transactionId : [NSNull null],
                                                            nil]];


### PR DESCRIPTION
`BleError` has to be passed as a json string instead of json object (NSDictionary) to keep Blemulator in line with real adapter.