### PR TITLE
Fix NPE when using lower case for defining UUIDs of services/characteristics

### DIFF
--- a/android/src/main/java/com/polidea/blemulator/SimulatedAdapter.java
+++ b/android/src/main/java/com/polidea/blemulator/SimulatedAdapter.java
@@ -271,7 +271,7 @@ public class SimulatedAdapter implements BleAdapter {
 
     @Override
     public Service[] getServicesForDevice(String deviceIdentifier) throws BleError {
-        Log.i(TAG, "discoverAllServicesAndCharacteristicsForDevice");
+        Log.i(TAG, "getServicesForDevice");
         if (knownPeripherals.get(deviceIdentifier) == null) {
             throw new BleError(BleErrorCode.DeviceNotFound, "Device unknown", 0);
         }
@@ -292,7 +292,7 @@ public class SimulatedAdapter implements BleAdapter {
     @Override
     public Characteristic[] getCharacteristicsForDevice(String deviceIdentifier,
                                                         String serviceUUID) throws BleError {
-        Log.i(TAG, "discoverAllServicesAndCharacteristicsForDevice");
+        Log.i(TAG, "getCharacteristicsForDevice");
 
         if (knownPeripherals.get(deviceIdentifier) == null) {
             throw new BleError(BleErrorCode.DeviceNotFound, "Device unknown", 0);
@@ -315,7 +315,7 @@ public class SimulatedAdapter implements BleAdapter {
 
     @Override
     public Characteristic[] getCharacteristicsForService(int serviceIdentifier) throws BleError {
-        Log.i(TAG, "discoverAllServicesAndCharacteristicsForDevice");
+        Log.i(TAG, "getCharacteristicForService");
 
 
         for (DeviceContainer deviceContainer : knownPeripherals.values()) {
@@ -324,7 +324,7 @@ public class SimulatedAdapter implements BleAdapter {
                     if (service.getId() == serviceIdentifier) {
                         return deviceContainer
                                 .getCharacteristics()
-                                .get(service.getUuid().toString().toUpperCase())
+                                .get(service.getUuid().toString().toUpperCase()) //HERE; TODO remove mark
                                 .toArray(new Characteristic[0]);
                     }
                 }

--- a/android/src/main/java/com/polidea/blemulator/SimulatedAdapter.java
+++ b/android/src/main/java/com/polidea/blemulator/SimulatedAdapter.java
@@ -324,7 +324,7 @@ public class SimulatedAdapter implements BleAdapter {
                     if (service.getId() == serviceIdentifier) {
                         return deviceContainer
                                 .getCharacteristics()
-                                .get(service.getUuid().toString().toUpperCase()) //HERE; TODO remove mark
+                                .get(service.getUuid().toString().toUpperCase())
                                 .toArray(new Characteristic[0]);
                     }
                 }

--- a/android/src/main/java/com/polidea/blemulator/bridging/DartMethodCaller.java
+++ b/android/src/main/java/com/polidea/blemulator/bridging/DartMethodCaller.java
@@ -233,7 +233,7 @@ public class DartMethodCaller {
         for (Map<String, Object> mappedService : response) {
             Service service = serviceDartValueDecoder.decode(deviceIdentifier, mappedService);
             services.add(service);
-            characteristics.put((String) mappedService.get(SimulationArgumentName.SERVICE_UUID),
+            characteristics.put(((String) mappedService.get(SimulationArgumentName.SERVICE_UUID)).toUpperCase(),
                     parseCharacteristicsForServicesResponse(
                             (List<Map<String, Object>>) mappedService.get(SimulationArgumentName.CHARACTERISTICS))
             );


### PR DESCRIPTION
Fixes #66 

Issue was caused by using case specified by the user to store data in the map, instead of readjusting it to one format.