### PR TITLE
Let user set characteristic's value without sending notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ class ExampleCharacteristic extends SimulatedCharacteristic {
             convenienceName: convenienceName);
 
   @override
-  Future<void> write(Uint8List value) {
+  Future<void> write(Uint8List value, { bool sendNotification = true }) {
     int valueAsInt = value[0];
     if (valueAsInt != 0 && valueAsInt != 1) {
       return Future.error(SimulatedBleError(

--- a/example/lib/example_peripheral.dart
+++ b/example/lib/example_peripheral.dart
@@ -98,6 +98,16 @@ class TemperatureService extends SimulatedService {
             convenienceName: convenienceName) {
     characteristicByUuid(_temperatureConfigUuid).monitor().listen((value) {
       _readingTemperature = value[0] == 1;
+
+      if (_readingTemperature) {
+        SimulatedCharacteristic temperatureDataCharacteristic =
+            characteristicByUuid(_temperatureDataUuid);
+
+        temperatureDataCharacteristic.write(
+          Uint8List.fromList([0, 0, 100, Random().nextInt(255)]),
+          sendNotification: false,
+        );
+      }
     });
 
     _emitTemperature();
@@ -116,7 +126,7 @@ class TemperatureService extends SimulatedService {
       if (temperatureDataCharacteristic.isNotifying) {
         if (_readingTemperature) {
           temperatureDataCharacteristic
-              .write(Uint8List.fromList([0, 0, 200, Random().nextInt(255)]));
+              .write(Uint8List.fromList([0, 0, 100, Random().nextInt(255)]));
         } else {
           temperatureDataCharacteristic.write(Uint8List.fromList([0, 0, 0, 0]));
         }
@@ -134,7 +144,7 @@ class BooleanCharacteristic extends SimulatedCharacteristic {
             convenienceName: convenienceName);
 
   @override
-  Future<void> write(Uint8List value) {
+  Future<void> write(Uint8List value, {bool sendNotification = true}) {
     int valueAsInt = value[0];
     if (valueAsInt != 0 && valueAsInt != 1) {
       return Future.error(SimulatedBleError(

--- a/lib/simulation/simulated_characteristic.dart
+++ b/lib/simulation/simulated_characteristic.dart
@@ -33,9 +33,9 @@ class SimulatedCharacteristic {
 
   Future<Uint8List> read() async => _value;
 
-  Future<void> write(Uint8List value) async {
+  Future<void> write(Uint8List value, {bool sendNotification = true}) async {
     this._value = value;
-    if (_streamController?.hasListener == true)
+    if (sendNotification && _streamController?.hasListener == true)
       _streamController.sink.add(value);
   }
 


### PR DESCRIPTION
User was unable to set characteristic's value in response to some event, but without interfering with the notification cycle. 

By adding optional parameter to decide whether the notification should be sent or not, the whole solution gains more flexibility.