### PR TITLE
Removed Kotlin releted lines from build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,14 +21,10 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 28
 
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
     defaultConfig {
         minSdkVersion 18
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
`apply plugin: 'kotlin-android'` caused build errors on Android. 