### PR TITLE
Restore previous version of example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,7 @@
+import 'package:blemulator_example/device_details/device_detail_view.dart';
+import 'package:blemulator_example/device_details/devices_details_bloc_provider.dart';
+import 'package:blemulator_example/devices_list/devices_bloc_provider.dart';
+import 'package:blemulator_example/devices_list/devices_list_view.dart';
 import 'package:blemulator_example/navigation/bloc.dart';
 import 'package:blemulator_example/navigation/route_name.dart';
 import 'package:blemulator_example/navigation/router.dart';
@@ -16,14 +20,35 @@ final RouteObserver<PageRoute> routeObserver = RouteObserver<PageRoute>();
 
 class MyApp extends StatelessWidget {
   final GlobalKey<NavigatorState> _navigatorKey = GlobalKey();
+  final bool useNewExample = false;
 
   @override
   Widget build(BuildContext context) {
+    return useNewExample ? _buildNewExample() : _buildExample();
+  }
+
+  Widget _buildExample() {
+    return MaterialApp(title: 'Blemulator example',
+      theme: new ThemeData(
+        primaryColor: new Color(0xFF0A3D91),
+        accentColor: new Color(0xFFCC0000),
+      ),
+      initialRoute: "/",
+      routes: <String, WidgetBuilder>{
+        "/": (context) => DevicesBlocProvider(child: DevicesListScreen()),
+        "/details": (context) =>
+            DeviceDetailsBlocProvider(child: DeviceDetailsView()),
+      },
+      navigatorObservers: [routeObserver],
+    );
+  }
+
+  Widget _buildNewExample() {
     return BlocProvider<NavigationBloc>(
       builder: (context) => NavigationBloc(navigatorKey: _navigatorKey),
       child: MaterialApp(
         navigatorKey: _navigatorKey,
-        title: 'FlutterBleLib example',
+        title: 'Blemulator example',
         theme: ThemeData(
           primaryColor: CustomColors.primary,
           accentColor: CustomColors.accent,


### PR DESCRIPTION
Since new version of the example app is not fully functional yet, it is required to restore the previous version prior to official plugin release.