### PR TITLE
[iOS] Fix Service JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 
-* Fix issue where accessing characteristic's properties were null on iOS
+* Fix an issue causing characteristics' properties to be null on iOS
 
 ## 0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 
-* iOS - Fix Service JSON parsing
+* Fix issue where accessing characteristic's properties were null on iOS
 
 ## 0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* iOS - Fix Service JSON parsing
+
 ## 0.0.1
 
 * TODO: Describe initial release.

--- a/ios/Classes/Bridging/Converter/DartCallArgumentsConverter.m
+++ b/ios/Classes/Bridging/Converter/DartCallArgumentsConverter.m
@@ -45,7 +45,8 @@
 
 + (Characteristic *)characteristicFromCallArguments:(NSDictionary<NSString *,id> *)callArguments {
     return [DomainTypesConverter characteristicFromDictionary:callArguments
-                                                      service:[DomainTypesConverter serviceFromDictionary:callArguments]];
+                                                      service:[DomainTypesConverter serviceFromDictionary:callArguments
+                                                                                 withPeripheralIdentifier:[callArguments objectForKey:DART_CALL_ARGUMENT_DEVICE_IDENTIFIER]]];
 }
 
 + (BleError *)bleErrorFromCallArguments:(NSDictionary<NSString *,id> *)callArguments {

--- a/ios/Classes/Bridging/Converter/DartResultConverter.m
+++ b/ios/Classes/Bridging/Converter/DartResultConverter.m
@@ -12,7 +12,8 @@
     NSMutableDictionary<NSString *, NSArray<Characteristic *> *> *characteristics = [[NSMutableDictionary alloc] init];
 
     for (NSDictionary *serviceDictionary in resultArray) {
-        Service *service = [DomainTypesConverter serviceFromDictionary:serviceDictionary];
+        Service *service = [DomainTypesConverter serviceFromDictionary:serviceDictionary
+                                              withPeripheralIdentifier:peripheral.identifier];
 
         NSMutableArray *characteristicsArray = [[NSMutableArray alloc] init];
         for (NSDictionary *characteristicDictionary in [serviceDictionary objectForKey:DART_RESULT_CHARACTERISTICS]) {
@@ -33,7 +34,8 @@
 + (Characteristic *)characteristicFromDartResult:(id)result {
     NSDictionary *resultDictionary = (NSDictionary *)result;
     return [DomainTypesConverter characteristicFromDictionary:resultDictionary
-                                      service:[DomainTypesConverter serviceFromDictionary:resultDictionary]];
+                                                      service:[DomainTypesConverter serviceFromDictionary:resultDictionary
+                                                                                 withPeripheralIdentifier:[resultDictionary objectForKey:DART_RESULT_DEVICE_IDENTIFIER]]];
 }
 
 @end

--- a/ios/Classes/Bridging/Converter/DomainTypesConverter.h
+++ b/ios/Classes/Bridging/Converter/DomainTypesConverter.h
@@ -3,7 +3,8 @@
 
 @interface DomainTypesConverter: NSObject
 
-+ (Service *)serviceFromDictionary:(NSDictionary *)dictionary;
++ (Service *)serviceFromDictionary:(NSDictionary *)dictionary
+          withPeripheralIdentifier:(NSString *)peripheralIdentifier;
 
 + (Characteristic *)characteristicFromDictionary:(NSDictionary *)dictionary service:(Service *)service;
 

--- a/ios/Classes/Bridging/Converter/DomainTypesConverter.m
+++ b/ios/Classes/Bridging/Converter/DomainTypesConverter.m
@@ -3,10 +3,11 @@
 
 @implementation DomainTypesConverter
 
-+ (Service *)serviceFromDictionary:(NSDictionary *)dictionary {
++ (Service *)serviceFromDictionary:(NSDictionary *)dictionary
+          withPeripheralIdentifier:(NSString *)peripheralIdentifier {
     return [[Service alloc] initWithObjectId:[[dictionary objectForKey:DART_RESULT_SERVICE_ID] intValue]
                                         uuid:[CBUUID UUIDWithString:[dictionary objectForKey:DART_RESULT_SERVICE_UUID]]
-                        peripheralIdentifier:[dictionary objectForKey:DART_RESULT_DEVICE_IDENTIFIER]
+                        peripheralIdentifier:peripheralIdentifier
                                    isPrimary:true];
 }
 


### PR DESCRIPTION
Added `peripheralIdentifier` argument to the `DomainTypesConverter.serviceFromDictionary` method to provide identifier directly.