### PR TITLE
Add support for connecting to peripheral without launching scan first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+* Add support for connecting to peripheral without launching scan first
+
 ## 1.1.3
 
 * Fix incorrect iOS plugin class name causing `Duplicate plugin key: FlutterBleLib`

--- a/android/src/main/java/com/polidea/blemulator/SimulatedAdapter.java
+++ b/android/src/main/java/com/polidea/blemulator/SimulatedAdapter.java
@@ -217,6 +217,12 @@ public class SimulatedAdapter implements BleAdapter {
 
         dartValueHandler.addConnectionStatePublisher(deviceIdentifier, onEventCallback);
 
+        if (!knownPeripherals.containsKey(deviceIdentifier)) {
+            knownPeripherals.put(deviceIdentifier,
+                    new DeviceContainer(deviceIdentifier, "", null, null)
+            );
+        }
+
         dartMethodCaller.connectToDevice(
                 deviceIdentifier,
                 knownPeripherals.get(deviceIdentifier).getName(),

--- a/ios/Classes/SimulatedAdapter.m
+++ b/ios/Classes/SimulatedAdapter.m
@@ -151,6 +151,13 @@
                  reject:(Reject)reject {
     NSLog(@"SimulatedAdapter.connectToDevice");
     self.dartValueHandler.connectionEventDelegate = self;
+    
+    if ([self.knownPeripherals objectForKey:deviceIdentifier] != nil) {
+            [self.knownPeripherals setObject:[[DeviceContainer alloc] initWithIdentifier:deviceIdentifier
+                                                          name:@""]
+            forKey:deviceIdentifier];
+    }
+    
     [self.dartMethodCaller connectToDevice:deviceIdentifier
                                       name:[self.knownPeripherals objectForKey:deviceIdentifier].name
                                    options:options


### PR DESCRIPTION
Polidea/FlutterBleLib#295