### PR TITLE
Updaded flutter_ble_lib to 2.3.2

### DIFF
--- a/ios/blemulator.podspec
+++ b/ios/blemulator.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'blemulator'
-  s.version          = '1.2.1'
+  s.version          = '1.2.2'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'MultiplatformBleAdapter', '~> 0.1.7'
+  s.dependency 'MultiplatformBleAdapter', '~> 0.1.8'
 
   s.ios.deployment_target = '8.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: blemulator
 description: Flutter plugin for simulating BLE peripherals on FlutterBleLib
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/Polidea/blemulator_flutter
 
 environment:
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_ble_lib: ^2.3.1
+  flutter_ble_lib: ^2.3.2
   async: ^2.4.0
   meta: ^1.1.8
   pedantic: ^1.9.0


### PR DESCRIPTION
This is required to have the dependency on both `flutter_ble_lib` and `blemulator` in the project.