### PR TITLE
Update to new Flutter version method/syntax fixes #131.

### DIFF
--- a/example/lib/device_details/devices_details_bloc_provider.dart
+++ b/example/lib/device_details/devices_details_bloc_provider.dart
@@ -4,7 +4,6 @@ import 'package:flutter_ble_lib/flutter_ble_lib.dart';
 
 import 'device_details_bloc.dart';
 
-
 class DeviceDetailsBlocProvider extends InheritedWidget {
   final DeviceDetailsBloc deviceDetailsBloc;
 
@@ -12,14 +11,15 @@ class DeviceDetailsBlocProvider extends InheritedWidget {
     Key key,
     DeviceDetailsBloc deviceDetailsBloc,
     Widget child,
-  })  : deviceDetailsBloc = deviceDetailsBloc ?? DeviceDetailsBloc(DeviceRepository(), BleManager()),
+  })  : deviceDetailsBloc = deviceDetailsBloc ??
+            DeviceDetailsBloc(DeviceRepository(), BleManager()),
         super(key: key, child: child);
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) => true;
 
   static DeviceDetailsBloc of(BuildContext context) =>
-      (context.inheritFromWidgetOfExactType(DeviceDetailsBlocProvider)
+      (context.dependOnInheritedWidgetOfExactType()
               as DeviceDetailsBlocProvider)
           .deviceDetailsBloc;
 }

--- a/example/lib/devices_list/devices_bloc_provider.dart
+++ b/example/lib/devices_list/devices_bloc_provider.dart
@@ -10,15 +10,14 @@ class DevicesBlocProvider extends InheritedWidget {
     Key key,
     DevicesBloc devicesBloc,
     Widget child,
-  })  : devicesBloc = devicesBloc ??
-            DevicesBloc(DeviceRepository(), BleManager()),
+  })  : devicesBloc =
+            devicesBloc ?? DevicesBloc(DeviceRepository(), BleManager()),
         super(key: key, child: child);
 
   @override
   bool updateShouldNotify(InheritedWidget oldWidget) => true;
 
   static DevicesBloc of(BuildContext context) =>
-      (context.inheritFromWidgetOfExactType(DevicesBlocProvider)
-              as DevicesBlocProvider)
+      (context.dependOnInheritedWidgetOfExactType() as DevicesBlocProvider)
           .devicesBloc;
 }


### PR DESCRIPTION
Based on https://stackoverflow.com/a/66092545/2223106 but apparently the type declarations mentioned there are not necessary now.